### PR TITLE
Add `endermanGriefing` gamerule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,10 @@ jar {
 	}
 }
 
+loom {
+	accessWidener = file("src/main/resources/convenient-mobgriefing.accesswidener")
+}
+
 // configure the maven publication
 // publishing {
 // 	publications {

--- a/src/main/java/io/github/a5b84/convenientmobgriefing/Mod.java
+++ b/src/main/java/io/github/a5b84/convenientmobgriefing/Mod.java
@@ -10,6 +10,7 @@ public class Mod implements ModInitializer {
 
     public static final GameRules.Key<BooleanRule>
             LENIENT_GRIEFING = register("lenientGriefing"),
+            ENDERMAN_GRIEFING = register("endermanGriefing"),
             WITHER_GRIEFING = register("witherGriefing"),
             DRAGON_GRIEFING = register("dragonGriefing");
 

--- a/src/main/java/io/github/a5b84/convenientmobgriefing/mixin/RulesImpl.java
+++ b/src/main/java/io/github/a5b84/convenientmobgriefing/mixin/RulesImpl.java
@@ -9,6 +9,8 @@ import net.minecraft.entity.ai.goal.EatGrassGoal;
 import net.minecraft.entity.ai.goal.StepAndDestroyBlockGoal;
 import net.minecraft.entity.boss.WitherEntity;
 import net.minecraft.entity.boss.dragon.EnderDragonEntity;
+import net.minecraft.entity.mob.EndermanEntity.PlaceBlockGoal;
+import net.minecraft.entity.mob.EndermanEntity.PickUpBlockGoal;
 import net.minecraft.entity.mob.EvokerEntity.WololoGoal;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.mob.PiglinEntity;
@@ -22,6 +24,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 import static io.github.a5b84.convenientmobgriefing.Mod.DRAGON_GRIEFING;
+import static io.github.a5b84.convenientmobgriefing.Mod.ENDERMAN_GRIEFING;
 import static io.github.a5b84.convenientmobgriefing.Mod.LENIENT_GRIEFING;
 import static io.github.a5b84.convenientmobgriefing.Mod.WITHER_GRIEFING;
 
@@ -147,6 +150,30 @@ public final class RulesImpl {
             }
         }
 
+    }
+
+
+
+    /** endermanGriefing implementation */
+    public static final class Enderman {
+
+        private Enderman() {}
+
+        @Mixin(PlaceBlockGoal.class)
+        public static abstract class PlaceBlockGoalMixin {
+            @ModifyArg(method = "canStart", at = @At(value = "INVOKE", target = TARGET))
+            private Key<BooleanRule> mobGriefingProxy(Key<BooleanRule> old) {
+                return ENDERMAN_GRIEFING;
+            }
+        }
+
+        @Mixin(PickUpBlockGoal.class)
+        public static abstract class PickUpBlockGoalMixin {
+            @ModifyArg(method = "canStart", at = @At(value = "INVOKE", target = TARGET))
+            private Key<BooleanRule> mobGriefingProxy(Key<BooleanRule> old) {
+                return ENDERMAN_GRIEFING;
+            }
+        }
     }
 
 

--- a/src/main/resources/assets/convenient-mobgriefing/lang/en_us.json
+++ b/src/main/resources/assets/convenient-mobgriefing/lang/en_us.json
@@ -1,6 +1,8 @@
 {
     "gamerule.lenientGriefing": "Allow non-destructive mob actions",
     "gamerule.lenientGriefing.description": "Overrides the vanilla mobGriefing game rule. Controls passive mob actions like Villager farming, Piglin bartering, mobs picking up items, ...",
+    "gamerule.endermanGriefing": "Allow Enderman actions",
+    "gamerule.endermanGriefing.description": "Overrides the vanilla mobGriefing game rule.",
     "gamerule.dragonGriefing": "Allow Ender Dragon griefing",
     "gamerule.dragonGriefing.description": "Overrides the vanilla mobGriefing game rule.",
     "gamerule.witherGriefing": "Allow Wither griefing",

--- a/src/main/resources/assets/convenient-mobgriefing/lang/fr_fr.json
+++ b/src/main/resources/assets/convenient-mobgriefing/lang/fr_fr.json
@@ -1,6 +1,8 @@
 {
     "gamerule.lenientGriefing": "Actions passives de mobs",
     "gamerule.lenientGriefing.description": "Remplace la règle 'mobGriefing' vanilla. Permet aux mobs de faire des actions passives comme cultiver les champs pour les PNJs, troquer avec les piglins, ramasser et des items, etc.",
+    "gamerule.endermanGriefing": "Destruction par le Enderman",
+    "gamerule.endermanGriefing.description": "Remplace la règle 'mobGriefing' vanilla.",
     "gamerule.dragonGriefing": "Destruction par l'Ender Dragon",
     "gamerule.dragonGriefing.description": "Remplace la règle 'mobGriefing' vanilla.",
     "gamerule.witherGriefing": "Destruction par le Wither",

--- a/src/main/resources/convenient-mobgriefing.accesswidener
+++ b/src/main/resources/convenient-mobgriefing.accesswidener
@@ -1,0 +1,4 @@
+accessWidener	v1	named
+
+accessible	class	net/minecraft/entity/mob/EndermanEntity$PlaceBlockGoal
+accessible	class	net/minecraft/entity/mob/EndermanEntity$PickUpBlockGoal

--- a/src/main/resources/convenient-mobgriefing.mixins.json
+++ b/src/main/resources/convenient-mobgriefing.mixins.json
@@ -14,6 +14,8 @@
     "RulesImpl$Lenient$PiglinEntityMixin",
     "RulesImpl$Lenient$EatSweetBerriesGoalMixin",
     "RulesImpl$Lenient$LivingEntityMixin",
+    "RulesImpl$Enderman$PlaceBlockGoalMixin",
+    "RulesImpl$Enderman$PickUpBlockGoalMixin",
     "RulesImpl$Wither$WitherEntityMixin",
     "RulesImpl$Wither$WitherSkullEntityMixin",
     "RulesImpl$Dragon$EnderDragonEntityMixin"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,6 +24,7 @@
   "mixins": [
     "convenient-mobgriefing.mixins.json"
   ],
+  "accessWidener" : "convenient-mobgriefing.accesswidener",
 
   "depends": {
     "fabric-game-rule-api-v1": "*"


### PR DESCRIPTION
This PR separates enderman picking up and placing blocks from `mobGriefing`, as some redstone farms rely on this feature to work (e.g. an [Enderman Melon Farm](https://www.youtube.com/watch?v=jBma-2qAgno)), so they may expect the endermans to keep their behavior while still preventing creepers from blowing up the buildings.

This PR is a breaking change since `mobGriefing` gamerule will not control enderman's picking up and placing block after merged.